### PR TITLE
Add URL check

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,8 @@
                     bzURL = site;
                     document.getElementById("textSiteURL").value = bzURL;
                 }
+                // Check site first so we don't leave the user without feed back
+                checkURL(bzURL);
 
                 document.getElementById("textProduct").value = bzProduct;
                 document.getElementById("textMilestone").value = bzProductMilestone;
@@ -241,6 +243,21 @@
             function stopSpinner() {
                 var elem = document.getElementById("spinner");
                 elem.removeChild(elem.firstChild);
+            }
+
+            function checkURL(url) {
+                var xhr = new XMLHttpRequest();
+                xhr.onreadystatechange = function() {
+                    if (xhr.readyState == XMLHttpRequest.DONE) {
+                        var response = xhr.responseText;
+                        if (response == "") { // Working response is "5.0" for example
+                            alert("Unable to access Bugzilla REST : " + bzURL);
+                            return;
+                        }
+                    }
+                }
+                xhr.open("GET", bzURL + "/rest/version");
+                xhr.send();
             }
 
             // Register event handlers


### PR DESCRIPTION
UI doesn't show if wrong site info provided.

Noticed if the hard-coded or site parameter was wrong, the interface doesn't show failure. 
