### PR TITLE
Backlog

### DIFF
--- a/bzkanban.css
+++ b/bzkanban.css
@@ -48,6 +48,10 @@ body {
     border-radius: 0 0 3px 3px;
     background: #E2E4E6;
 }
+#BACKLOG .board-column-title,
+#BACKLOG .board-column-content {
+    background: darkgrey;
+}
 .card {
     background-color: white;
     border-radius: 3px;

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -10,7 +10,6 @@ var bzLoadComments = false;
 var bzCheckForUpdates = true;
 var bzAutoRefresh = false;
 var bzDomElement = "#bzkanban";
-var bzBacklogSearch = "&target_milestone=---&resolution=---";
 var bzBacklogDefaultStatus = "CONFIRMED";
 
 // "Private" global variables. Do not touch.
@@ -23,6 +22,7 @@ var bzUserFullName = "";
 var bzProductHasUnconfirmed = false;
 var bzBoardLoadTime = "";
 var bzRestGetBugsUrl = "";
+var bzRestGetBacklogUrl = "";
 var bzAssignees = new Map();
 var bzProductComponents;
 var bzProductVersions;
@@ -1120,7 +1120,15 @@ function hideBacklog() {
 
 function loadBacklogCards() {
     showSpinner();
-    httpGet("/rest.cgi/bug?product=" + bzProduct + bzBacklogSearch, function(response) {
+    bzRestGetBacklogUrl = "/rest.cgi/bug?product=" + bzProduct;
+    bzRestGetBacklogUrl += "&include_fields=summary,status,id,severity,priority,assigned_to,last_updated,deadline";
+    bzRestGetBacklogUrl += "&order=" + bzOrder;
+    bzRestGetBacklogUrl += "&target_milestone=---";
+    bzRestGetBacklogUrl += "&resolution=---";
+    bzRestGetBacklogUrl += "&component=" + bzComponent;
+    bzRestGetBacklogUrl += "&priority=" + bzPriority;
+
+    httpGet(bzRestGetBacklogUrl, function(response) {
         hideSpinner();
         var bugs = response.bugs;
         var backlogCards = document.querySelector("#BACKLOG" + " .cards");

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1137,8 +1137,10 @@ function isBacklogVisible() {
         return false;
     }
 }
+
 function loadBacklogCards() {
     showSpinner();
+
     bzRestGetBacklogUrl = "/rest.cgi/bug?product=" + bzProduct;
     bzRestGetBacklogUrl += "&include_fields=summary,status,id,severity,priority,assigned_to,last_updated,deadline";
     bzRestGetBacklogUrl += "&order=" + bzOrder;

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -216,12 +216,11 @@ function createBacklogButton() {
     backlogShowButton.id = "btnShowBacklog";
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.addEventListener("click", function() {
-        var backlogCol = document.querySelector("#BACKLOG.board-column");
         if (bzProduct === "") {
             alert ("Select a product first");
             return;
         }
-        if (backlogCol.style.display === "none") {
+        if (!isBacklogVisible()) {
             showBacklog();
         } else {
             hideBacklog();
@@ -342,6 +341,9 @@ function loadBoard() {
     clearAssigneesList();
     clearCards();
     loadBugs();
+    if (isBacklogVisible()) {
+        loadBacklogCards();
+    }
 }
 
 function loadBugs() {
@@ -1094,10 +1096,10 @@ function showBacklog() {
     var button = document.getElementById("btnShowBacklog");
     var backlogCol = document.querySelector("#BACKLOG.board-column");
 
-    if (backlogCol.style.display === "none") {
-        // Load backlog on first access.
+    if (!isBacklogVisible()) {
         var backlog = backlogCol.querySelector(".cards");
         if (backlog.children.length == 0) {
+            // Load backlog on first access.
             loadBacklogCards();
         }
 
@@ -1110,13 +1112,22 @@ function hideBacklog() {
     var button = document.getElementById("btnShowBacklog");
     var backlogCol = document.querySelector("#BACKLOG.board-column");
 
-    if (backlogCol.style.display === "" || null) {
+    if (isBacklogVisible()) {
         var backlog = backlogCol.querySelector(".cards");
         backlogCol.style.display = "none";
         button.innerText = "Show Backlog";
     }
 }
 
+function isBacklogVisible() {
+    var backlogCol = document.querySelector("#BACKLOG.board-column");
+
+    if (backlogCol.style.display === "") {
+        return true;
+    } else {
+        return false;
+    }
+}
 function loadBacklogCards() {
     showSpinner();
     bzRestGetBacklogUrl = "/rest.cgi/bug?product=" + bzProduct;

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -88,9 +88,6 @@ function initNav() {
     document.querySelector(bzDomElement).appendChild(nav);
 
     nav.appendChild(createQueryFields());
-    if (bzAllowEditBugs) {
-        nav.appendChild(createBacklogButton());
-    }
 
     var spring = document.createElement("span");
     spring.className = "spring";
@@ -219,6 +216,10 @@ function createBacklogButton() {
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.addEventListener("click", function() {
         var backlogCol = document.querySelector("#BACKLOG.board-column");
+        if (bzProduct === "") {
+            alert ("Select a product first");
+            return;
+        }
         if (backlogCol.style.display === "none") {
             showBacklog();
         } else {
@@ -271,6 +272,7 @@ function createActions() {
     bell.id = "notification";
     bell.className = "fa fa-bell";
 
+    actions.appendChild(createBacklogButton());
     actions.appendChild(newbug);
     actions.appendChild(whoami);
     actions.appendChild(login);

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1147,6 +1147,9 @@ function loadBacklogCards() {
             var card = createCard(bug);
             backlogCards.appendChild(card);
         });
+
+        // force a recount now that we have a new column.
+        showColumnCounts();
     });
 }
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -10,7 +10,7 @@ var bzLoadComments = false;
 var bzCheckForUpdates = true;
 var bzAutoRefresh = false;
 var bzDomElement = "#bzkanban";
-var bzBacklogSearch = "&target_milestone=---&bug_status=UNCONFIRMED&bug_status=CONFIRMED";
+var bzBacklogSearch = "&target_milestone=---&resolution=---";
 
 // "Private" global variables. Do not touch.
 var bzProduct = "";

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -149,6 +149,7 @@ function createQueryFields() {
         clearAssigneesList();
         clearCards();
         updateAddressBar();
+        hideBacklogButton();
         hideNewBugButton();
         hideNotification();
     });
@@ -170,6 +171,7 @@ function createQueryFields() {
 
         // Clear affected state.
         bzAssignedTo = "";
+        showBacklogButton();
         showNewBugButton();
         hideNotification();
 
@@ -215,11 +217,8 @@ function createBacklogButton() {
     var backlogShowButton = document.createElement("button");
     backlogShowButton.id = "btnShowBacklog";
     backlogShowButton.innerText = "Show Backlog";
+    backlogShowButton.style.display = "none";
     backlogShowButton.addEventListener("click", function() {
-        if (bzProduct === "") {
-            alert ("Select a product first");
-            return;
-        }
         if (!isBacklogVisible()) {
             showBacklog();
         } else {
@@ -912,6 +911,16 @@ function showSpinner() {
 function hideSpinner() {
     var spinner = document.querySelector('#spinner');
     spinner.style.display = 'none';
+}
+
+function showBacklogButton() {
+    var btn = document.querySelector('#btnShowBacklog');
+    btn.style.display = 'initial';
+}
+
+function hideBacklogButton() {
+    var btn = document.querySelector('#btnShowBacklog');
+    btn.style.display = 'none';
 }
 
 function showNewBugButton() {

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1069,35 +1069,17 @@ function dropCard(ev) {
     ev.preventDefault();
 
     var bugCurrent = JSON.parse(ev.dataTransfer.getData("text"));
+
+    var bugUpdate = {};
+    bugUpdate.id = bugCurrent.id;
     if (ev.currentTarget.id === "BACKLOG") {
-        dropBacklog(ev, bugCurrent);
-        return;
-    }
-
-    var bugUpdate = {};
-    bugUpdate.id = bugCurrent.id;
-    bugUpdate.status = ev.currentTarget.id;
-    bugUpdate.target_milestone = bzProductMilestone;
-
-    ev.target.classList.remove("drop-target-hover");
-
-    if (bzAddCommentOnChange) {
-        showBugModal(bugCurrent, bugUpdate);
+        bugUpdate.status = bzBacklogDefaultStatus;
+        bugUpdate.target_milestone = "---";
+        bugUpdate.priority = bzDefaultPriority;
     } else {
-        writeBug(bugUpdate);
+        bugUpdate.status = ev.currentTarget.id;
+        bugUpdate.target_milestone = bzProductMilestone;
     }
-}
-
-function dropBacklog(ev, bugCurrent) {
-//    ev.preventDefault();
-
-//    var bugCurrent = JSON.parse(ev.dataTransfer.getData("text"));
-
-    var bugUpdate = {};
-    bugUpdate.id = bugCurrent.id;
-    bugUpdate.status = bzBacklogDefaultStatus;
-    bugUpdate.target_milestone = "---";
-    bugUpdate.priority = bzDefaultPriority;
 
     ev.target.classList.remove("drop-target-hover");
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -342,6 +342,7 @@ function loadBoard() {
     clearAssigneesList();
     clearCards();
     loadBugs();
+    loadBacklogCards();
 }
 
 function loadBugs() {

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -10,8 +10,7 @@ var bzLoadComments = false;
 var bzCheckForUpdates = true;
 var bzAutoRefresh = false;
 var bzDomElement = "#bzkanban";
-var backlogTitle = "BACKLOG";
-var backlogSearch = "&target_milestone=---&bug_status=UNCONFIRMED&bug_status=CONFIRMED";
+var bzBacklogSearch = "&target_milestone=---&bug_status=UNCONFIRMED&bug_status=CONFIRMED";
 
 // "Private" global variables. Do not touch.
 var bzProduct = "";
@@ -231,11 +230,11 @@ function createBacklogTarget() {
 
 function createBacklogButton() {
     var backlogShowButton = document.createElement("button");
-    backlogShowButton.id = "btnShow" + backlogTitle;
+    backlogShowButton.id = "btnShowBacklog";
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.addEventListener("click", function() {
-        var button = document.getElementById("btnShow" + backlogTitle);
-        var backlogCol = document.querySelector("#" + backlogTitle + ".board-column");
+        var button = document.getElementById("btnShowBacklog");
+        var backlogCol = document.querySelector("#BACKLOG.board-column");
         if (backlogCol.style.display === "none") {
             // Load backlog on first access.
             var backlog = backlogCol.querySelector(".cards");
@@ -470,7 +469,7 @@ function loadProductInfo() {
 function loadColumns() {
     httpGet("/rest.cgi/field/bug/status/values", function(response) {
         // Always add a backlog as first column
-        var backlog = addBoardColumn(backlogTitle);
+        var backlog = addBoardColumn("BACKLOG");
         backlog.style.display = 'none';
 
         var statuses = response.values;
@@ -1139,10 +1138,10 @@ function hideBacklog() {
 
 function loadBacklogCards() {
     showSpinner();
-    httpGet("/rest.cgi/bug?product=" + bzProduct + backlogSearch, function(response) {
+    httpGet("/rest.cgi/bug?product=" + bzProduct + bzBacklogSearch, function(response) {
         hideSpinner();
         var bugs = response.bugs;
-        var backlogCards = document.querySelector("#" + backlogTitle + " .cards");
+        var backlogCards = document.querySelector("#BACKLOG" + " .cards");
 
         bugs.forEach(function(bug) {
             var card = createCard(bug);

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -234,11 +234,16 @@ function createBacklogButton() {
     backlogShowButton.id = "btnShow" + backlogTitle;
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.toggle = false;
-    backlogShowButton.style.display = "none";
     backlogShowButton.addEventListener("click", function() {
         var button = document.getElementById("btnShow" + backlogTitle);
         var backlogCol = document.querySelector("#" + backlogTitle + ".board-column");
         if (!button.toggle) {
+            // Load backlog on first access.
+            var backlog = backlogCol.querySelector(".cards");
+            if (backlog.children.length == 0) {
+                loadBacklogCards();
+            }
+
             backlogCol.style.display = null;
             button.innerText = "Hide Backlog";
             button.toggle = true;
@@ -362,7 +367,6 @@ function loadBoard() {
     clearAssigneesList();
     clearCards();
     loadBugs();
-    loadBacklogCards(backlogTitle);
 }
 
 function loadBugs() {
@@ -1135,11 +1139,8 @@ function hideBacklog() {
     document.getElementById("textBacklog").style.display = "none";
 }
 
-function loadBacklogCards(column) {
+function loadBacklogCards() {
     httpGet("/rest.cgi/bug?product=" + bzProduct + backlogSearch, function(response) {
-        addBoardColumn(column, "before");
-        document.getElementById("btnShow" + column).style.display = null;
-        document.querySelector("#" + backlogTitle + ".board-column").style.display = "none";
         var bugs = response.bugs;
         var backlogCards = document.querySelector("#" + backlogTitle + " .cards");
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -218,7 +218,12 @@ function createBacklogButton() {
     backlogShowButton.id = "btnShowBacklog";
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.addEventListener("click", function() {
-        toggleBacklog();
+        var backlogCol = document.querySelector("#BACKLOG.board-column");
+        if (backlogCol.style.display === "none") {
+            showBacklog();
+        } else {
+            hideBacklog();
+        }
     });
 
     return backlogShowButton;
@@ -1097,15 +1102,6 @@ function dropBacklog(ev, bugCurrent) {
         showBugModal(bugCurrent, bugUpdate);
     } else {
         writeBug(bugUpdate);
-    }
-}
-
-function toggleBacklog() {
-    var backlogCol = document.querySelector("#BACKLOG.board-column");
-    if (backlogCol.style.display === "none") {
-        showBacklog();
-    } else {
-        hideBacklog();
     }
 }
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -237,12 +237,13 @@ function createBacklogButton() {
     backlogShowButton.style.display = "none";
     backlogShowButton.addEventListener("click", function() {
         var button = document.getElementById("btnShow" + backlogTitle);
+        var backlogCol = document.querySelector("#" + backlogTitle + ".board-column");
         if (!button.toggle) {
-            document.querySelector("#" + backlogTitle + ".board-column").style.display = null;
+            backlogCol.style.display = null;
             button.innerText = "Hide Backlog";
             button.toggle = true;
         } else {
-            document.querySelector("#" + backlogTitle + ".board-column").style.display = "none";
+            backlogCol.style.display = "none";
             button.innerText = "Show Backlog";
             button.toggle = false;
         }

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -11,6 +11,7 @@ var bzCheckForUpdates = true;
 var bzAutoRefresh = false;
 var bzDomElement = "#bzkanban";
 var bzBacklogSearch = "&target_milestone=---&resolution=---";
+var bzBacklogDefaultStatus = "CONFIRMED";
 
 // "Private" global variables. Do not touch.
 var bzProduct = "";
@@ -1094,7 +1095,7 @@ function dropBacklog(ev, bugCurrent) {
 
     var bugUpdate = {};
     bugUpdate.id = bugCurrent.id;
-    bugUpdate.status = "SUBMITTED";
+    bugUpdate.status = bzBacklogDefaultStatus;
     bugUpdate.target_milestone = "---";
     bugUpdate.priority = bzDefaultPriority;
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -234,6 +234,7 @@ function createBacklogButton() {
     backlogShowButton.id = "btnShow" + backlogTitle;
     backlogShowButton.innerText = "Show Backlog";
     backlogShowButton.toggle = false;
+    backlogShowButton.style.display = "none";
     backlogShowButton.addEventListener("click", function() {
         var button = document.getElementById("btnShow" + backlogTitle);
         if (!button.toggle) {
@@ -1136,6 +1137,7 @@ function hideBacklog() {
 function loadBacklogCards(column) {
     httpGet("/rest.cgi/bug?product=" + bzProduct + backlogSearch, function(response) {
         addBoardColumn(column, "before");
+        document.getElementById("btnShow" + column).style.display = null;
         document.querySelector("#" + backlogTitle + ".board-column").style.display = "none";
         var bugs = response.bugs;
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -472,9 +472,13 @@ function loadProductInfo() {
 
 function loadColumns() {
     httpGet("/rest.cgi/field/bug/status/values", function(response) {
+        // Always add a backlog as first column
+        var backlog = addBoardColumn(backlogTitle);
+        backlog.style.display = 'none';
+
         var statuses = response.values;
         statuses.forEach(function(status) {
-            addBoardColumn(status, "after");
+            addBoardColumn(status);
         });
         updateUnconfirmedColumnVisibilty();
 
@@ -628,7 +632,7 @@ function loadDefaultMilestone() {
     });
 }
 
-function addBoardColumn(status, direction) {
+function addBoardColumn(status) {
     var div = document.createElement('div');
     div.className = "board-column";
     div.id = status;
@@ -654,13 +658,9 @@ function addBoardColumn(status, direction) {
     cards.className = "cards";
     content.appendChild(cards);
 
-    if (direction === "after") {
-        document.getElementById("board").appendChild(div);
-    }
-    if (direction === "before") {
-        var board = document.getElementById("board");
-        board.insertBefore(div, board.childNodes[0]);
-    }
+    document.getElementById("board").appendChild(div);
+
+    return div;
 }
 
 function createCard(bug) {

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -233,11 +233,10 @@ function createBacklogButton() {
     var backlogShowButton = document.createElement("button");
     backlogShowButton.id = "btnShow" + backlogTitle;
     backlogShowButton.innerText = "Show Backlog";
-    backlogShowButton.toggle = false;
     backlogShowButton.addEventListener("click", function() {
         var button = document.getElementById("btnShow" + backlogTitle);
         var backlogCol = document.querySelector("#" + backlogTitle + ".board-column");
-        if (!button.toggle) {
+        if (backlogCol.style.display === "none") {
             // Load backlog on first access.
             var backlog = backlogCol.querySelector(".cards");
             if (backlog.children.length == 0) {
@@ -246,11 +245,9 @@ function createBacklogButton() {
 
             backlogCol.style.display = null;
             button.innerText = "Hide Backlog";
-            button.toggle = true;
         } else {
             backlogCol.style.display = "none";
             button.innerText = "Show Backlog";
-            button.toggle = false;
         }
     });
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1140,7 +1140,9 @@ function hideBacklog() {
 }
 
 function loadBacklogCards() {
+    showSpinner();
     httpGet("/rest.cgi/bug?product=" + bzProduct + backlogSearch, function(response) {
+        hideSpinner();
         var bugs = response.bugs;
         var backlogCards = document.querySelector("#" + backlogTitle + " .cards");
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1098,6 +1098,7 @@ function dropCard(ev) {
     var bugUpdate = {};
     bugUpdate.id = bugCurrent.id;
     bugUpdate.status = ev.currentTarget.id;
+    bugUpdate.target_milestone = bzProductMilestone;
 
     ev.target.classList.remove("drop-target-hover");
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -342,7 +342,6 @@ function loadBoard() {
     clearAssigneesList();
     clearCards();
     loadBugs();
-    loadBacklogCards();
 }
 
 function loadBugs() {

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1141,10 +1141,11 @@ function loadBacklogCards(column) {
         document.getElementById("btnShow" + column).style.display = null;
         document.querySelector("#" + backlogTitle + ".board-column").style.display = "none";
         var bugs = response.bugs;
+        var backlogCards = document.querySelector("#" + backlogTitle + " .cards");
 
         bugs.forEach(function(bug) {
             var card = createCard(bug);
-            document.querySelector("#" + column + " .cards").appendChild(card);
+            backlogCards.appendChild(card);
         });
     });
 }

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1095,7 +1095,7 @@ function showBacklog() {
     var button = document.getElementById("btnShowBacklog");
     var backlogCol = document.querySelector("#BACKLOG.board-column");
 
-    if (backlogCol.style.display === "none" || null) {
+    if (backlogCol.style.display === "none") {
         // Load backlog on first access.
         var backlog = backlogCol.querySelector(".cards");
         if (backlog.children.length == 0) {


### PR DESCRIPTION
Ability to show the default 'null' (---) milestone of a product, even when a different milestone is loaded. 
This is also filtering for unconfirmed/confirmed bugs.
Displayed as an extra column on the left, for quick reorganizing of cards.

The search query at the global vars allows this to be modified as needed. 