### PR TITLE
Modal column with comments

### DIFF
--- a/bzkanban.css
+++ b/bzkanban.css
@@ -208,7 +208,7 @@ body {
     margin: auto;
     flex-direction: column;
     align-items: flex-start;
-    width: 700px;
+    width: 44em;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
     animation-name: animatetop;
     animation-duration: 0.4s;
@@ -252,6 +252,7 @@ body {
     padding: 15px;
     align-self: stretch;
     min-height: 4vh;
+    overflow-y: auto;
 }
 .modal-body input,
 .modal-body select {
@@ -275,15 +276,14 @@ body {
 .bug-comments {
     display: flex;
     flex-direction: column;
-    flex: 0.8;
-    overflow-y: auto;
+    overflow-wrap: break-word;
 }
 .bug-meta {
     display: flex;
     flex-direction: column;
     font-size: x-small;
     margin-left: 10px;
-    flex: 0.2;
+    width: 100%;
 }
 .bug-comment {
     border-style: solid;
@@ -293,6 +293,7 @@ body {
     padding: 7px;
     font-weight: normal;
     font-size: small;
+    width: 36em;
 }
 select, textarea, input, button {
     padding: 3px;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -215,6 +215,7 @@ body {
     border-width: 1px;
     border-color: black;
     border-style: solid;
+    max-height: 80%;
 }
 @keyframes animatetop {
     from {
@@ -250,6 +251,7 @@ body {
     display: flex;
     padding: 15px;
     align-self: stretch;
+    min-height: 4vh;
 }
 .modal-body input,
 .modal-body select {
@@ -274,6 +276,7 @@ body {
     display: flex;
     flex-direction: column;
     flex: 0.8;
+    overflow-y: auto;
 }
 .bug-meta {
     display: flex;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -285,7 +285,7 @@ body {
     margin-left: 10px;
     flex: 0.2;
 }
-.bug-description {
+.bug-comment {
     border-style: solid;
     border-color: darkgrey;
     border-width: thin;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -275,7 +275,7 @@ body {
     display: flex;
     flex-direction: column;
     overflow-wrap: break-word;
-    width: 75%;
+    min-width: 75%;
 }
 .bug-meta {
     display: flex;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -277,7 +277,7 @@ body {
     display: flex;
     flex-direction: column;
     overflow-wrap: break-word;
-    width: 120em;
+    width: 75%;
 }
 .bug-meta {
     display: flex;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -208,7 +208,7 @@ body {
     margin: auto;
     flex-direction: column;
     align-items: flex-start;
-    width: 600px;
+    width: 700px;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
     animation-name: animatetop;
     animation-duration: 0.4s;
@@ -239,11 +239,16 @@ body {
     align-self: stretch;
     font-size: x-large;
 }
+.modal-body {
+    flex-direction: row;
+}
+.modal-footer {
+    flex-direction: column;
+}
 .modal-body,
 .modal-footer {
     display: flex;
     padding: 15px;
-    flex-direction: column;
     align-self: stretch;
 }
 .modal-body input,
@@ -267,10 +272,14 @@ body {
 .bug-comments {
     display: flex;
     flex-direction: column;
+    flex: 0.8;
 }
 .bug-meta {
     display: flex;
     flex-direction: column;
+    font-size: x-small;
+    margin-left: 10px;
+    flex: 0.2;
 }
 .bug-description {
     border-style: solid;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -277,6 +277,7 @@ body {
     display: flex;
     flex-direction: column;
     overflow-wrap: break-word;
+    width: 120em;
 }
 .bug-meta {
     display: flex;
@@ -293,7 +294,6 @@ body {
     padding: 7px;
     font-weight: normal;
     font-size: small;
-    width: 36em;
 }
 select, textarea, input, button {
     padding: 3px;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -258,6 +258,7 @@ body {
 .modal-body textarea {
     width: 100%;
     height: 100px;
+    resize: vertical;
 }
 .modal-body label {
     margin-top: 10px;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -240,16 +240,11 @@ body {
     align-self: stretch;
     font-size: x-large;
 }
-.modal-body {
-    flex-direction: row;
-}
-.modal-footer {
-    flex-direction: column;
-}
 .modal-body,
 .modal-footer {
     display: flex;
     padding: 15px;
+    flex-direction: column;
     align-self: stretch;
     min-height: 4vh;
     overflow-y: auto;
@@ -272,6 +267,9 @@ body {
 }
 .modal-footer button {
     align-self: flex-end;
+}
+#modalBug .modal-body {
+    flex-direction: row;
 }
 .bug-comments {
     display: flex;

--- a/bzkanban.css
+++ b/bzkanban.css
@@ -276,6 +276,7 @@ body {
     flex-direction: column;
     overflow-wrap: break-word;
     min-width: 75%;
+    max-width: 75%;
 }
 .bug-meta {
     display: flex;

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1400,32 +1400,23 @@ function showBugModal(bugCurrent, bugUpdate) {
         httpGet("/rest/bug/" + bugCurrent.id + "/comment?include_fields=text", function(response) {
             hideSpinner();
             var commentsObj = response.bugs[bugCurrent.id].comments;
-            var comment;
 
-            for (comment in commentsObj) {
+            for (var comment in commentsObj) {
+                var commentLabel = document.createElement("label");
                 if (comment === "0") {
-                    // Description
-                    var descriptionLabel = document.createElement("label");
-                    descriptionLabel.innerText = "Description";
-                    var description = document.createElement("div");
-                    description.className = "bug-description";
-                    description.innerText = commentsObj[0].text;
-
-                    descriptionLabel.appendChild(description);
-                    comments.appendChild(descriptionLabel);
-                    comments.appendChild(createCommentsBox());
+                    commentLabel.innerText = "Description";
                 } else {
-                    // Show existing comments
-                    var commentLabel = document.createElement("label");
                     commentLabel.innerText = "Comment " + comment;
-                    var otherCommentsBox = document.createElement("div");
-                    otherCommentsBox.className = "bug-description";
-                    otherCommentsBox.innerText = commentsObj[comment].text;
-
-                    commentLabel.appendChild(otherCommentsBox);
-                    comments.appendChild(commentLabel);
                 }
+                var commentText = document.createElement("div");
+                commentText.className = "bug-description";
+                commentText.innerText = commentsObj[comment].text;
+
+                commentLabel.appendChild(commentText);
+                comments.appendChild(commentLabel);
             }
+
+            comments.appendChild(createCommentsBox());
         });
 
         // Priority field.

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1395,19 +1395,44 @@ function showBugModal(bugCurrent, bugUpdate) {
     // Card was clicked
     if (bugCurrent.status === bugUpdate.status) {
 
-        // Description field
-        var descriptionLabel = document.createElement("label");
-        descriptionLabel.innerText = "Description";
-        var description = document.createElement("div");
-        description.className = "bug-description";
+        // Show comments and description
         httpGet("/rest/bug/" + bugCurrent.id + "/comment?include_fields=text", function(response) {
-            var comment0 = response.bugs[bugCurrent.id].comments[0].text;
-            description.innerText = comment0;
-        });
-        descriptionLabel.appendChild(description);
-        comments.appendChild(descriptionLabel);
+            var commentsObj = response.bugs[bugCurrent.id].comments;
+            var comment;
 
-        // TODO show bug comments?
+            for (comment in commentsObj) {
+                if (comment === "0") {
+                    // Description
+                    var descriptionLabel = document.createElement("label");
+                    descriptionLabel.innerText = "Description";
+                    var description = document.createElement("div");
+                    description.className = "bug-description";
+                    description.innerText = commentsObj[0].text;
+
+                    descriptionLabel.appendChild(description);
+                    comments.appendChild(descriptionLabel);
+
+                    // Add enterable textarea for new comment
+                    var commentBoxLabel = document.createElement("label");
+                    commentBoxLabel.innerText = "Additional Comments";
+                    var commentBox = document.createElement("textarea");
+                    commentBox.id = "commentBoxText";
+
+                    commentBoxLabel.appendChild(commentBox);
+                    comments.appendChild(commentBoxLabel);
+                } else {
+                    // Show existing comments
+                    var commentLabel = document.createElement("label");
+                    commentLabel.innerText = "Comment " + comment;
+                    var otherCommentsBox = document.createElement("div");
+                    otherCommentsBox.className = "bug-description";
+                    otherCommentsBox.innerText = commentsObj[comment].text;
+
+                    commentLabel.appendChild(otherCommentsBox);
+                    comments.appendChild(commentLabel);
+                }
+            }
+        });
 
         // Priority field.
         var priorityLabel = document.createElement("label");
@@ -1460,14 +1485,6 @@ function showBugModal(bugCurrent, bugUpdate) {
         meta.appendChild(severityLabel);
     }
 
-    var commentBoxLabel = document.createElement("label");
-    commentBoxLabel.innerText = "Additional Comments";
-
-    var commentBox = document.createElement("textarea");
-    commentBox.id = "commentBoxText";
-
-    commentBoxLabel.appendChild(commentBox);
-
     var submit = document.createElement("button");
     submit.innerText = "Submit";
     submit.id = "submitComment";
@@ -1477,8 +1494,6 @@ function showBugModal(bugCurrent, bugUpdate) {
         hideModal();
         writeBug(bugUpdate);
     };
-
-    comments.appendChild(commentBoxLabel);
 
     footer.appendChild(submit);
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1396,6 +1396,8 @@ function showBugModal(bugCurrent, bugUpdate) {
     // Card was clicked
     if (bugCurrent.status === bugUpdate.status) {
 
+        body.style.display = "none"; // HACK: hide until comments reponse comes back so layout isn't broken.
+
         // Show comments and description
         httpGet("/rest/bug/" + bugCurrent.id + "/comment?include_fields=text", function(response) {
             hideSpinner();
@@ -1417,6 +1419,8 @@ function showBugModal(bugCurrent, bugUpdate) {
             }
 
             comments.appendChild(createCommentsBox());
+
+            body.style.display = null; // unhide it
         });
 
         // Priority field.

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1409,7 +1409,7 @@ function showBugModal(bugCurrent, bugUpdate) {
                     commentLabel.innerText = "Comment " + comment;
                 }
                 var commentText = document.createElement("div");
-                commentText.className = "bug-description";
+                commentText.className = "bug-comment";
                 commentText.innerText = commentsObj[comment].text;
 
                 commentLabel.appendChild(commentText);

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1362,6 +1362,7 @@ function showBugModal(bugCurrent, bugUpdate) {
     meta.className = 'bug-meta';
 
     body.appendChild(comments);
+    showSpinner();
     body.appendChild(meta);
 
     // TODO replace hard coded column name somehow.
@@ -1397,6 +1398,7 @@ function showBugModal(bugCurrent, bugUpdate) {
 
         // Show comments and description
         httpGet("/rest/bug/" + bugCurrent.id + "/comment?include_fields=text", function(response) {
+            hideSpinner();
             var commentsObj = response.bugs[bugCurrent.id].comments;
             var comment;
 
@@ -1476,6 +1478,7 @@ function showBugModal(bugCurrent, bugUpdate) {
 
         meta.appendChild(severityLabel);
     } else {
+        hideSpinner();
         comments.appendChild(createCommentsBox());
     }
 

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1411,15 +1411,7 @@ function showBugModal(bugCurrent, bugUpdate) {
 
                     descriptionLabel.appendChild(description);
                     comments.appendChild(descriptionLabel);
-
-                    // Add enterable textarea for new comment
-                    var commentBoxLabel = document.createElement("label");
-                    commentBoxLabel.innerText = "Additional Comments";
-                    var commentBox = document.createElement("textarea");
-                    commentBox.id = "commentBoxText";
-
-                    commentBoxLabel.appendChild(commentBox);
-                    comments.appendChild(commentBoxLabel);
+                    comments.appendChild(createCommentsBox());
                 } else {
                     // Show existing comments
                     var commentLabel = document.createElement("label");
@@ -1483,6 +1475,8 @@ function showBugModal(bugCurrent, bugUpdate) {
         };
 
         meta.appendChild(severityLabel);
+    } else {
+        comments.appendChild(createCommentsBox());
     }
 
     var submit = document.createElement("button");
@@ -1505,6 +1499,18 @@ function hideModal() {
     if (modal !== null) {
         modal.remove();
     }
+}
+
+function createCommentsBox() {
+    // Add enterable textarea for new comment
+    var commentBoxLabel = document.createElement("label");
+    commentBoxLabel.innerText = "Additional Comments";
+    var commentBox = document.createElement("textarea");
+    commentBox.id = "commentBoxText";
+
+    commentBoxLabel.appendChild(commentBox);
+
+    return commentBoxLabel;
 }
 
 // Register event handlers

--- a/bzkanban.js
+++ b/bzkanban.js
@@ -1362,7 +1362,6 @@ function showBugModal(bugCurrent, bugUpdate) {
     meta.className = 'bug-meta';
 
     body.appendChild(comments);
-    showSpinner();
     body.appendChild(meta);
 
     // TODO replace hard coded column name somehow.
@@ -1397,6 +1396,8 @@ function showBugModal(bugCurrent, bugUpdate) {
     if (bugCurrent.status === bugUpdate.status) {
 
         body.style.display = "none"; // HACK: hide until comments reponse comes back so layout isn't broken.
+
+        showSpinner();
 
         // Show comments and description
         httpGet("/rest/bug/" + bugCurrent.id + "/comment?include_fields=text", function(response) {
@@ -1473,7 +1474,6 @@ function showBugModal(bugCurrent, bugUpdate) {
 
         meta.appendChild(severityLabel);
     } else {
-        hideSpinner();
         comments.appendChild(createCommentsBox());
     }
 


### PR DESCRIPTION
Split up the modal layout to be in columns. Following the styling queues of Github issue tracker, comments on the left and metadata on the right.